### PR TITLE
JSON generation/round-trip is incomplete

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -1,0 +1,12 @@
+name: rake
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ v* ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rake:
+    uses: metanorma/ci/.github/workflows/graphviz-rake.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: |
+          Next release version. Possible values: x.y.z, major, minor, patch or pre|rc|etc
+        required: true
+        default: 'skip'
+  push:
+    tags: [ v* ]
+
+jobs:
+  release:
+    uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
+    with:
+      next_version: ${{ github.event.inputs.next_version }}
+    secrets:
+      rubygems-api-key: ${{ secrets.LUTAML_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.LUTAML_CI_PAT_TOKEN }}
+

--- a/lib/genericode/code_list.rb
+++ b/lib/genericode/code_list.rb
@@ -42,7 +42,7 @@ module Genericode
 
     def column_set_to_json(model, doc)
       doc["Columns"] = model.column_set.column.map do |col|
-        col.to_json
+        Shale.json_adapter.load(col.to_json)
       end
     end
 
@@ -59,7 +59,7 @@ module Genericode
 
     def key_to_json(model, doc)
       doc["Keys"] = model.column_set.key.map do |key|
-        key.to_json
+        Shale.json_adapter.load(key.to_json)
       end
     end
 

--- a/lib/genericode/json/short_name_mixin.rb
+++ b/lib/genericode/json/short_name_mixin.rb
@@ -6,7 +6,7 @@ module Genericode
       end
 
       def short_name_to_json(model, doc)
-        doc["short_name"] = model.short_name.content
+        doc["ShortName"] = model.short_name.content unless model.short_name.nil?
       end
     end
   end

--- a/spec/genericode_spec.rb
+++ b/spec/genericode_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe Genericode do
         it "performs a round-trip conversion" do
           parsed = Genericode::CodeList.from_json(json_string)
           generated = Genericode::CodeList.to_json(parsed)
-          puts parsed.to_json(pretty: true)
           reparsed = Genericode::CodeList.from_json(generated)
 
           expect(reparsed.identification.short_name.content).to eq(parsed.identification.short_name.content)

--- a/spec/genericode_spec.rb
+++ b/spec/genericode_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe Genericode do
           generated = Genericode::CodeList.to_json(parsed)
           reparsed = Genericode::CodeList.from_json(generated)
 
+          original_to_test = JSON.parse(json_string).to_json
+          reparsed_to_test = JSON.parse(reparsed.to_json).to_json
+
           expect(reparsed.identification.short_name.content).to eq(parsed.identification.short_name.content)
           expect(reparsed.column_set.column.size).to eq(parsed.column_set.column.size)
           expect(reparsed.simple_code_list.row.size).to eq(parsed.simple_code_list.row.size)
+
+          expect(reparsed_to_test).to eq(original_to_test)
         end
       end
     end


### PR DESCRIPTION
The commit ee14813 adds a test for to_json/from_json JSON compare (normalized).

The errors are:
```
Genericode
  XML round-trip conversion
    with file CaseTypeCode.gc
      performs a round-trip conversion
    with file ChannelCode-2.3.gc
      performs a round-trip conversion
    with file CurrencyCode-2.3.gc
      performs a round-trip conversion
    with file UnitOfMeasureCode-2.3.gc
      performs a round-trip conversion
  JSON round-trip conversion
    with file CaseTypeCode.gcj
      performs a round-trip conversion (FAILED - 1)
    with file ChannelCode-2.3.gcj
      performs a round-trip conversion (FAILED - 2)
    with file CurrencyCode-2.3.gcj
      performs a round-trip conversion (FAILED - 3)
    with file UnitOfMeasureCode-2.3.gcj
      performs a round-trip conversion (FAILED - 4)

Failures:

  1) Genericode JSON round-trip conversion with file CaseTypeCode.gcj performs a round-trip conversion
     Failure/Error: expect(reparsed_to_test).to eq(original_to_test)
     
       expected: "{\"Annotation\":{\"http://example.org/namespace/genericode-appinfo\":{\"ConformanceTargets\":{\"http...n\"},{\"code\":\"civil\"},{\"code\":\"criminal\"},{\"code\":\"domestic\"},{\"code\":\"juvenile\"}]}"
            got: "{\"Annotation\":{\"Description\":[]},\"Identification\":{\"ShortName\":\"CaseTypeCode\",\"LongName\"...n\"},{\"code\":\"civil\"},{\"code\":\"criminal\"},{\"code\":\"domestic\"},{\"code\":\"juvenile\"}]}"
     
       (compared using ==)
     # ./spec/genericode_spec.rb:54:in `block (5 levels) in <top (required)>'

  2) Genericode JSON round-trip conversion with file ChannelCode-2.3.gcj performs a round-trip conversion
     Failure/Error: expect(reparsed_to_test).to eq(original_to_test)
     
       expected: "{\"Identification\":{\"ShortName\":\"ChannelCode\",\"LongName\":[{\"http://www.w3.org/XML/1998/names..."National telephone switchboard\",\"description\":\"The national telephone switchboard number.\"}]}"
            got: "{\"Identification\":{\"ShortName\":\"ChannelCode\",\"LongName\":[{\"_\":\"Channel Code\"},{\"_\":\"U..."National telephone switchboard\",\"description\":\"The national telephone switchboard number.\"}]}"
     
       (compared using ==)
     # ./spec/genericode_spec.rb:54:in `block (5 levels) in <top (required)>'

  3) Genericode JSON round-trip conversion with file CurrencyCode-2.3.gcj performs a round-trip conversion
     Failure/Error: expect(reparsed_to_test).to eq(original_to_test)
     
       expected: "{\"Identification\":{\"ShortName\":\"CurrencyCode\",\"LongName\":[{\"http://www.w3.org/XML/1998/name...:\"Zimbabwe Dollar\",\"numericcode\":\"932\",\"fractionaldigits\":\"2\",\"country\":\"ZIMBABWE\"}]}"
            got: "{\"Identification\":{\"ShortName\":\"CurrencyCode\",\"LongName\":[{\"_\":\"Currency Code\"},{\"_\":\...:\"Zimbabwe Dollar\",\"numericcode\":\"932\",\"fractionaldigits\":\"2\",\"country\":\"ZIMBABWE\"}]}"
     
       (compared using ==)
     # ./spec/genericode_spec.rb:54:in `block (5 levels) in <top (required)>'

  4) Genericode JSON round-trip conversion with file UnitOfMeasureCode-2.3.gcj performs a round-trip conversion
     Failure/Error: expect(reparsed_to_test).to eq(original_to_test)
     
       expected: "{\"Identification\":{\"ShortName\":\"UnitOfMeasureCode\",\"LongName\":[{\"http://www.w3.org/XML/1998...\"A unit of measure as agreed in common between two or more parties.\",\"levelcategory\":\"3.9\"}]}"
            got: "{\"Identification\":{\"ShortName\":\"UnitOfMeasureCode\",\"LongName\":[{\"_\":\"Unit Of Measure Code...\"A unit of measure as agreed in common between two or more parties.\",\"levelcategory\":\"3.9\"}]}"
     
       (compared using ==)
     # ./spec/genericode_spec.rb:54:in `block (5 levels) in <top (required)>'

Finished in 0.69108 seconds (files took 0.11418 seconds to load)
8 examples, 4 failures

Failed examples:

rspec ./spec/genericode_spec.rb[1:2:1:1] # Genericode JSON round-trip conversion with file CaseTypeCode.gcj performs a round-trip conversion
rspec ./spec/genericode_spec.rb[1:2:2:1] # Genericode JSON round-trip conversion with file ChannelCode-2.3.gcj performs a round-trip conversion
rspec ./spec/genericode_spec.rb[1:2:3:1] # Genericode JSON round-trip conversion with file CurrencyCode-2.3.gcj performs a round-trip conversion
rspec ./spec/genericode_spec.rb[1:2:4:1] # Genericode JSON round-trip conversion with file UnitOfMeasureCode-2.3.gcj performs a round-trip conversion
```