### PR TITLE
Change Attribute Type to String

### DIFF
--- a/lib/genericode/value.rb
+++ b/lib/genericode/value.rb
@@ -9,7 +9,7 @@ require_relative "column_ref"
 
 module Genericode
   class Value < Lutaml::Model::Serializable
-    attribute :column_ref, ColumnRef
+    attribute :column_ref, :string
     attribute :annotation, Annotation
     attribute :simple_value, SimpleValue
     attribute :complex_value, AnyOtherContent


### PR DESCRIPTION
 This PR fixes the failing specs of dependent gem `genericode` in `lutaml-model` CI
[Example Failure Run](https://github.com/lutaml/lutaml-model/actions/runs/13065767679/job/36457789626)
 
 > @HassanAkbar for those two user gems, can you help make the necessary changes? Thanks! Let's merge this first.

 _Originally posted by @ronaldtse in https://github.com/lutaml/lutaml-model/issues/271#issuecomment-2626197362_
            